### PR TITLE
Add bootstrap.css link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Load the javascript and css and declare your Angular dependency
 
 ```html
 <link rel="stylesheet" href="bower_components/angular-advanced-searchbox/dist/angular-advanced-searchbox.min.css">
+<link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
 <script src="bower_components/angular-advanced-searchbox/dist/angular-advanced-searchbox-tpls.min.js"></script>
 ```
 


### PR DESCRIPTION
I'm currently not using Bootstrap in my Angular project. and without this link the bin image isn't showing, as well as the looking glass. 

adding the bootstrap.css solves this issue. I can image people using bootstrap understand not to implement this link and the rest can just follow the readme without having to sort out how to get the bin icon back.