### PR TITLE
Fixed browser back behaviour when removing queries

### DIFF
--- a/src/angular-advanced-searchbox.js
+++ b/src/angular-advanced-searchbox.js
@@ -171,8 +171,10 @@ angular.module('angular-advanced-searchbox', [])
                         var cursorPosition = getCurrentCaretPosition(e.target);
 
                         if (e.which == 8) { // backspace
-                            if (cursorPosition === 0)
+                            if (cursorPosition === 0) {
+                                e.preventDefault();
                                 $scope.editPrevious(searchParamIndex);
+                            }
 
                         } else if (e.which == 9) { // tab
                             if (e.shiftKey) {


### PR DESCRIPTION
When a user holds down backspace on removing the last suggested query, a browser may go back to a previous page.

This PR will prevent default behaviour when cursor index is at 0.