### PR TITLE
add data attribute (data-key) for better testability

### DIFF
--- a/src/angular-advanced-searchbox.html
+++ b/src/angular-advanced-searchbox.html
@@ -8,7 +8,7 @@
             <a ng-href="" ng-click="removeSearchParam($index)" role="button">
                 <span class="remove glyphicon glyphicon-trash"></span>
             </a>
-            <div class="key" ng-click="enterEditMode($event, $index)">{{searchParam.name}}:</div>
+            <div class="key" data-key="{{param.key}}" ng-click="enterEditMode($event, $index)">{{searchParam.name}}:</div>
             <div class="value">
                 <span ng-show="!searchParam.editMode" ng-click="enterEditMode($event, $index)">{{searchParam.value}}</span>
                 <input name="value"
@@ -44,6 +44,6 @@
     </div>
     <div class="search-parameter-suggestions" ng-show="parameters && focus">
         <span class="title">{{parametersLabel}}:</span>
-        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" ng-mousedown="addSearchParam(param)">{{param.name}}</span>
+        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" data-key="{{param.key}}" ng-mousedown="addSearchParam(param)">{{param.name}}</span>
     </div>
 </div>

--- a/src/angular-advanced-searchbox.html
+++ b/src/angular-advanced-searchbox.html
@@ -8,7 +8,7 @@
             <a ng-href="" ng-click="removeSearchParam($index)" role="button">
                 <span class="remove glyphicon glyphicon-trash"></span>
             </a>
-            <div class="key" data-key="{{param.key}}" ng-click="enterEditMode($event, $index)">{{searchParam.name}}:</div>
+            <div class="key" data-key="{{searchParam.key}}" ng-click="enterEditMode($event, $index)">{{searchParam.name}}:</div>
             <div class="value">
                 <span ng-show="!searchParam.editMode" ng-click="enterEditMode($event, $index)">{{searchParam.value}}</span>
                 <input name="value"
@@ -44,6 +44,6 @@
     </div>
     <div class="search-parameter-suggestions" ng-show="parameters && focus">
         <span class="title">{{parametersLabel}}:</span>
-        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" data-key="{{param.key}}" ng-mousedown="addSearchParam(param)">{{param.name}}</span>
+        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" data-key="{{searchParam.key}}" ng-mousedown="addSearchParam(param)">{{param.name}}</span>
     </div>
 </div>

--- a/src/angular-advanced-searchbox.html
+++ b/src/angular-advanced-searchbox.html
@@ -44,6 +44,6 @@
     </div>
     <div class="search-parameter-suggestions" ng-show="parameters && focus">
         <span class="title">{{parametersLabel}}:</span>
-        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" data-key="{{searchParam.key}}" ng-mousedown="addSearchParam(param)">{{param.name}}</span>
+        <span class="search-parameter" ng-repeat="param in parameters | filter:isUnsedParameter | limitTo:parametersDisplayLimit" data-key="{{searchParam.key}}" ng-mousedown="addSearchParam(param)">{{searchParam.key}}</span>
     </div>
 </div>


### PR DESCRIPTION
Hi,
there is no possibility to touch a search-parameter without using the 'param.name' if you use this for different languages in testing.
So I decided to use the 'param.key' which works perfectly and is unattached to the name.