### PR TITLE
add directive attribute to bind the component focus

### DIFF
--- a/src/angular-advanced-searchbox.js
+++ b/src/angular-advanced-searchbox.js
@@ -20,7 +20,8 @@ angular.module('angular-advanced-searchbox', [])
                 parametersLabel: '@',
                 parametersDisplayLimit: '=?',
                 placeholder: '@',
-                searchThrottleTime: '=?'
+                searchThrottleTime: '=?',
+                setSearchFocus: '=?'
             },
             replace: true,
             templateUrl: function(element, attr) {
@@ -36,7 +37,7 @@ angular.module('angular-advanced-searchbox', [])
                     $scope.searchThrottleTime = $scope.searchThrottleTime || 1000;
                     $scope.searchParams = [];
                     $scope.searchQuery = '';
-                    $scope.setSearchFocus = false;
+                    $scope.setSearchFocus = $scope.setSearchFocus || false;
                     var searchThrottleTimer;
                     var changeBuffer = [];
 


### PR DESCRIPTION
Add possibility to set the component initial state focused, and allow set focus by another component

Examples:
binding the property:
```
<nit-advanced-searchbox
  set-search-focus="searchFocus">
</nit-advanced-searchbox>
<a ng-click="focus = true">Set Focus</a>
```

just setting the initial state focused
```
<nit-advanced-searchbox
  set-search-focus="true">
</nit-advanced-searchbox>
```
