### PR TITLE
add support to Typeahead with object 

### DIFF
--- a/src/angular-advanced-searchbox.html
+++ b/src/angular-advanced-searchbox.html
@@ -10,7 +10,7 @@
             </a>
             <div class="key" data-key="{{searchParam.key}}" ng-click="enterEditMode($event, $index)">{{searchParam.name}}:</div>
             <div class="value">
-                <span ng-show="!searchParam.editMode" ng-click="enterEditMode($event, $index)">{{searchParam.value}}</span>
+                <span ng-show="!searchParam.editMode" ng-click="enterEditMode($event, $index)">{{searchParam.value | toString:searchParam.suggestedToString}}</span>
                 <input name="value"
                        type="{{searchParam.type}}"
                        nit-auto-size-input

--- a/src/angular-advanced-searchbox.js
+++ b/src/angular-advanced-searchbox.js
@@ -437,5 +437,11 @@ angular.module('angular-advanced-searchbox', [])
                 }
             };
         }
-    ]);
+    ])
+    .filter('toString', function() {
+        return function(input, customToString) {
+            customToString = customToString || String;
+            return customToString(input);
+        };
+    });
 })();


### PR DESCRIPTION
#53 
Like auto complete in ui.bootstrap, objects in array are rendered with `toString` method.
Ex:

``` javascript
var citys = [{id:1, name:'Berlin', toString(){ return thi.name}, {id:2, name:'London', toString(){ return this.name9o9}]
$scope.availableSearchParams = [
      { key: "name", name: "Name" },
      { key: "city", name: "City", suggestedValues: cities }
];
```
Or optionally you can use `suggestedToString` function to render suggestedValues, like this:

``` javascript
var citys = [{id:1, name:'Berlin'}, {id:2, name:'London'}]
var myToString = function(item){ return item.name };
$scope.availableSearchParams = [
     { key: "name", name: "Name" },
     { key: "city", name: "City", suggestedValues: cities, suggestedToString: myToString }
];
```